### PR TITLE
Feature/erikzenker/prometheus interface

### DIFF
--- a/lib/rooms/prometheus_stats.ex
+++ b/lib/rooms/prometheus_stats.ex
@@ -1,0 +1,39 @@
+defmodule SignalTower.PrometheusStats do
+  use Prometheus.Metric
+  @counter [name: :palava_joined_room_total,
+            labels: [],
+            help: "Number of peers joined a room"]
+
+  @counter [name: :palava_leave_room_total,
+            labels: [],
+            help: "Number of peers left a room"]
+
+  def reset() do
+    Counter.reset(name: :palava_joined_room_total)
+    Counter.reset(name: :palava_leave_room_total)
+  end
+
+  def join() do
+    Counter.inc(name: :palava_joined_room_total)
+  end
+
+  def leave() do
+    Counter.inc(name: :palava_leave_room_total)
+  end
+
+  def to_string() do
+    Prometheus.Format.Text.format
+  end
+end
+
+defmodule SignalTower.PrometheusHTTPHandler do
+  def init(req, _state) do
+    headers = :cowboy_req.headers(req)
+    body = SignalTower.PrometheusStats.to_string()
+
+    reply = :cowboy_req.reply(200, headers, body, req)
+    {:ok, reply, :no_state}
+  end
+
+  def terminate(_reason, _request, _state), do: :ok
+end

--- a/lib/signal_tower.ex
+++ b/lib/signal_tower.ex
@@ -16,10 +16,8 @@ defmodule SignalTower do
     {port, _} = Integer.parse(System.get_env("PALAVA_RTC_ADDRESS") || "4233")
 
     dispatch = :cowboy_router.compile([
-      {:_, [
-        {"/", SignalTower.WebsocketHandler, []},
-        {"/metrics", SignalTower.PrometheusHTTPHandler, []}
-      ]}
+      {"localhost", [{"/metrics", SignalTower.PrometheusHTTPHandler, []}]},
+      {:_,          [{"/", SignalTower.WebsocketHandler, []}]}
     ])
 
     {port, dispatch}

--- a/lib/signal_tower.ex
+++ b/lib/signal_tower.ex
@@ -16,7 +16,10 @@ defmodule SignalTower do
     {port, _} = Integer.parse(System.get_env("PALAVA_RTC_ADDRESS") || "4233")
 
     dispatch = :cowboy_router.compile([
-      {:_, [{"/[...]", SignalTower.WebsocketHandler, []}]}
+      {:_, [
+        {"/", SignalTower.WebsocketHandler, []},
+        {"/metrics", SignalTower.PrometheusHTTPHandler, []}
+      ]}
     ])
 
     {port, dispatch}

--- a/mix.exs
+++ b/mix.exs
@@ -14,7 +14,7 @@ defmodule SignalTower.MixProject do
   def application do
     [
       mod: { SignalTower, [] },
-      applications: [:logger, :cowboy, :poison]
+      applications: [:logger, :cowboy, :poison, :prometheus_ex]
     ]
   end
 
@@ -23,7 +23,8 @@ defmodule SignalTower.MixProject do
     [
       {:cowboy, "~> 2.6.0"},
       {:poison, "~> 4.0.1"},
-      {:distillery, "~> 2.0.12"}
+      {:distillery, "~> 2.0.12"},
+      {:prometheus_ex, "~> 3.0"}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,9 +1,11 @@
 %{
-  "artificery": {:hex, :artificery, "0.4.2", "3ded6e29e13113af52811c72f414d1e88f711410cac1b619ab3a2666bbd7efd4", [:mix], [], "hexpm"},
-  "cowboy": {:hex, :cowboy, "2.6.3", "99aa50e94e685557cad82e704457336a453d4abcb77839ad22dbe71f311fcc06", [:rebar3], [{:cowlib, "~> 2.7.3", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.7.1", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
-  "cowlib": {:hex, :cowlib, "2.7.3", "a7ffcd0917e6d50b4d5fb28e9e2085a0ceb3c97dea310505f7460ff5ed764ce9", [:rebar3], [], "hexpm"},
-  "distillery": {:hex, :distillery, "2.0.14", "25fc1cdad06282334dbf4a11b6e869cc002855c4e11825157498491df2eed594", [:mix], [{:artificery, "~> 0.2", [hex: :artificery, repo: "hexpm", optional: false]}], "hexpm"},
+  "artificery": {:hex, :artificery, "0.4.2", "3ded6e29e13113af52811c72f414d1e88f711410cac1b619ab3a2666bbd7efd4", [:mix], [], "hexpm", "514586f4312ef3709a3ccbd8e55f69455add235c1729656687bb781d10d0afdb"},
+  "cowboy": {:hex, :cowboy, "2.6.3", "99aa50e94e685557cad82e704457336a453d4abcb77839ad22dbe71f311fcc06", [:rebar3], [{:cowlib, "~> 2.7.3", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.7.1", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm", "e5580029080f3f1ad17436fb97b0d5ed2ed4e4815a96bac36b5a992e20f58db6"},
+  "cowlib": {:hex, :cowlib, "2.7.3", "a7ffcd0917e6d50b4d5fb28e9e2085a0ceb3c97dea310505f7460ff5ed764ce9", [:rebar3], [], "hexpm", "1e1a3d176d52daebbecbbcdfd27c27726076567905c2a9d7398c54da9d225761"},
+  "distillery": {:hex, :distillery, "2.0.14", "25fc1cdad06282334dbf4a11b6e869cc002855c4e11825157498491df2eed594", [:mix], [{:artificery, "~> 0.2", [hex: :artificery, repo: "hexpm", optional: false]}], "hexpm", "1bc4861534891c1e144271a5b566d61128ccdc64c7920fd97fb1be5062142e5f"},
   "parallel_stream": {:hex, :parallel_stream, "1.0.6", "b967be2b23f0f6787fab7ed681b4c45a215a81481fb62b01a5b750fa8f30f76c", [:mix], [], "hexpm"},
-  "poison": {:hex, :poison, "4.0.1", "bcb755a16fac91cad79bfe9fc3585bb07b9331e50cfe3420a24bcc2d735709ae", [:mix], [], "hexpm"},
-  "ranch": {:hex, :ranch, "1.7.1", "6b1fab51b49196860b733a49c07604465a47bdb78aa10c1c16a3d199f7f8c881", [:rebar3], [], "hexpm"},
+  "poison": {:hex, :poison, "4.0.1", "bcb755a16fac91cad79bfe9fc3585bb07b9331e50cfe3420a24bcc2d735709ae", [:mix], [], "hexpm", "ba8836feea4b394bb718a161fc59a288fe0109b5006d6bdf97b6badfcf6f0f25"},
+  "prometheus": {:hex, :prometheus, "4.5.0", "8f4a2246fe0beb50af0f77c5e0a5bb78fe575c34a9655d7f8bc743aad1c6bf76", [:mix, :rebar3], [], "hexpm", "679b5215480fff612b8351f45c839d995a07ce403e42ff02f1c6b20960d41a4e"},
+  "prometheus_ex": {:hex, :prometheus_ex, "3.0.5", "fa58cfd983487fc5ead331e9a3e0aa622c67232b3ec71710ced122c4c453a02f", [:mix], [{:prometheus, "~> 4.0", [hex: :prometheus, repo: "hexpm", optional: false]}], "hexpm", "9fd13404a48437e044b288b41f76e64acd9735fb8b0e3809f494811dfa66d0fb"},
+  "ranch": {:hex, :ranch, "1.7.1", "6b1fab51b49196860b733a49c07604465a47bdb78aa10c1c16a3d199f7f8c881", [:rebar3], [], "hexpm", "451d8527787df716d99dc36162fca05934915db0b6141bbdac2ea8d3c7afc7d7"},
 }

--- a/test/prometheus_stats_test.exs
+++ b/test/prometheus_stats_test.exs
@@ -1,0 +1,31 @@
+defmodule PrometheusStatsTest do
+  use ExUnit.Case, async: false
+
+  test "should return text formated metrics" do
+    assert(String.match?(SignalTower.PrometheusStats.to_string, ~r/palava_joined_room_total/))
+    assert(String.match?(SignalTower.PrometheusStats.to_string, ~r/palava_leave_room_total/))
+  end
+
+  test "should increment on join" do
+    SignalTower.PrometheusStats.reset
+    SignalTower.PrometheusStats.join
+    metric_map = to_map(SignalTower.PrometheusStats.to_string)
+    assert("1" == metric_map["palava_joined_room_total"])
+  end
+
+  test "should increment on leave" do
+    SignalTower.PrometheusStats.reset
+    SignalTower.PrometheusStats.leave
+    metric_map = to_map(SignalTower.PrometheusStats.to_string)
+    assert("1" == metric_map["palava_leave_room_total"])
+  end
+
+  defp to_map(text) do
+     text
+     |> String.split("\n")
+     |> Enum.reject(&String.starts_with?(&1, "#"))
+     |> Enum.reject(&(&1 ==  ""))
+     |> Enum.map(&String.split(&1, " "))
+     |> Map.new(&List.to_tuple/1)
+  end
+end


### PR DESCRIPTION
This PR add prometheus interface to the signaltower under the route `/metrics`.
Currently it exposes `palava_leave_room_total`, `palava_joined_room_total`, and `erlang_vm` metrics