### PR TITLE
feat: Add created/closed room prometheus metric

### DIFF
--- a/lib/signal_tower/prometheus_stats.ex
+++ b/lib/signal_tower/prometheus_stats.ex
@@ -1,21 +1,23 @@
 defmodule SignalTower.PrometheusStats do
   use Prometheus.Metric
-
-  @counter [
-    name: :palava_joined_room_total,
-    labels: [],
-    help: "Number of peers joined a room"
-  ]
-
-  @counter [
-    name: :palava_leave_room_total,
-    labels: [],
-    help: "Number of peers left a room"
-  ]
+  @counter [name: :palava_room_created_total, labels: [], help: "Number of rooms created"]
+  @counter [name: :palava_room_closed_total, labels: [], help: "Number of rooms closed"]
+  @counter [name: :palava_joined_room_total, labels: [], help: "Number of peers joined a room"]
+  @counter [name: :palava_leave_room_total, labels: [], help: "Number of peers left a room"]
 
   def reset() do
+    Counter.reset(name: :palava_room_created_total)
+    Counter.reset(name: :palava_room_closed_total)
     Counter.reset(name: :palava_joined_room_total)
     Counter.reset(name: :palava_leave_room_total)
+  end
+
+  def room_created() do
+    Counter.inc(name: :palava_room_created_total)
+  end
+
+  def room_closed() do
+    Counter.inc(name: :palava_room_closed_total)
   end
 
   def join() do

--- a/lib/signal_tower/room.ex
+++ b/lib/signal_tower/room.ex
@@ -23,6 +23,7 @@ defmodule SignalTower.Room do
 
   def init(room_id) do
     GenServer.cast(Stats, {:room_created, self()})
+    SignalTower.PrometheusStats.room_created()
     {:ok, {room_id, %{}}}
   end
 
@@ -101,6 +102,7 @@ defmodule SignalTower.Room do
         send_peer_left(next_members, peer_id)
         {:ok, {room_id, next_members}}
       else
+        SignalTower.PrometheusStats.room_closed()
         {:stop, {room_id, next_members}}
       end
     else

--- a/test/prometheus_stats_test.exs
+++ b/test/prometheus_stats_test.exs
@@ -4,8 +4,33 @@ defmodule PrometheusStatsTest do
   alias SignalTower.PrometheusStats
 
   test "should return text formated metrics" do
-    assert String.match?(PrometheusStats.to_string(), ~r/palava_joined_room_total/)
-    assert String.match?(PrometheusStats.to_string(), ~r/palava_leave_room_total/)
+    assert(String.match?(PrometheusStats.to_string(), ~r/palava_room_created_total/))
+    assert(String.match?(PrometheusStats.to_string(), ~r/palava_room_closed_total/))
+    assert(String.match?(PrometheusStats.to_string(), ~r/palava_joined_room_total/))
+    assert(String.match?(PrometheusStats.to_string(), ~r/palava_leave_room_total/))
+  end
+
+  test "should reset metrics" do
+    PrometheusStats.reset()
+    metric_map = to_map(PrometheusStats.to_string())
+    assert("0" == metric_map["palava_room_created_total"])
+    assert("0" == metric_map["palava_room_closed_total"])
+    assert("0" == metric_map["palava_joined_room_total"])
+    assert("0" == metric_map["palava_leave_room_total"])
+  end
+
+  test "should increment on room created" do
+    PrometheusStats.reset()
+    PrometheusStats.room_created()
+    metric_map = to_map(PrometheusStats.to_string())
+    assert("1" == metric_map["palava_room_created_total"])
+  end
+
+  test "should increment on room closed" do
+    PrometheusStats.reset()
+    PrometheusStats.room_closed()
+    metric_map = to_map(PrometheusStats.to_string())
+    assert("1" == metric_map["palava_room_closed_total"])
   end
 
   test "should increment on join" do


### PR DESCRIPTION
This PR adds the metrics `palava_room_created_total` and `palava_room_closed_total` which we can use to calculate the number of open rooms